### PR TITLE
Sh/performance: sprite positioning 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -427,7 +427,11 @@ div.car-body {
     transition: scale .25s .05s, opacity .5s;
     opacity: 0;
     visibility: hidden;
-    
+    display: none;
+
+    &[data-display="onscreen"] {
+      display: block;
+    }
     /* show only waypoint #1 if not yet hit, subsequently
      only show the waypoints after the one *currently* being hit */
     &:first-child:not(.hit),
@@ -539,13 +543,14 @@ div.car-body {
 }
 
 .emitter-object {
+  
   position: absolute;
   display: block;
-  left: var(--left);
-  top: var(--top);
-  transform-origin: left top;
+  left: 0;
+  top: 0;
+  transform-origin: center;
+  translate: calc(var(--left) + -50%) calc(var(--top) + -50%);
   rotate: var(--rot, 0deg);
-  transform: translate(-50%, -50%); 
   aspect-ratio: 1;
   overflow: hidden;
 
@@ -567,8 +572,9 @@ div.car-body {
     border-radius: 100%;
     
     img {
-      rotate: 90deg;
+      width: auto;
       object-fit: none;
+
     }
 
     &.dead::after {
@@ -637,7 +643,7 @@ div.car-body {
   to {
     opacity: 0;
     rotate: 0deg;
-    translate: 150px 0;
+    translate: calc(var(--left) + 150px) calc(var(--top));
     scale: 3;
   }
 }

--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@
       <span id="exhaustPopSprite" class="sprite exhaust"><img src='assets/car/exhaust-pop.png' alt='' class="pop"/></span>
       <span id="explosionsSprite" class="sprite explosion"><img src='assets/boom3.png' alt='' id="" class="explosion"/></span>
       <span id="ahornTreeSprite" class="sprite tree"><img src='assets/environment/ahorn-tree-s.png' alt='' id="" class="tree"/></span>
-      <span id="marshalSprite" class="sprite marshal"><img src="assets/people/oldman_walk_sheet_2.png" class="uv"/></span>
+      <span id="marshalSprite" class="sprite marshal"><img src="assets/people/oldman_walk_sheet_2.png" class="uv" width="512px" height="64px"/></span>
     </section>
 
     <section class="audio">

--- a/js/Emitter.js
+++ b/js/Emitter.js
@@ -24,15 +24,18 @@ export default class Emitter {
     this.targetLayer = targetLayer ? targetLayer : this.game.worldMap.querySelector('.track')
     this.img = this.sprite.querySelector('img');
     this.img.addEventListener('load', (e) => {
-      console.log(`🖼️ loaded ${e.target.src}, w: ${e.target.width}px`)
-      this.framesPerRow = Math.floor(this.img.width / this.width);
+      let path = new URL(e.target.src);
+      let file = path.pathname;
+      
+      console.log(`🖼️ loaded ${file}, w: ${this.img.width || e.target.width}, framesPerRow: ${this.framesPerRow}`)
+      this.framesPerRow = Math.floor(e.target.width / this.width);
     })
 
     this.framesPerRow = Math.floor(this.img.width / this.width);
 
     if (this.maxFrame == 1) {
-      this.frameX = 1;
-      this.frameY = 1;
+      this.frameX = 0;
+      this.frameY = 0;
     }
 
     this.sprite.style.setProperty('--spriteHeight', this.height.toFixed(2));
@@ -79,8 +82,12 @@ export default class Emitter {
           }
         }
 
-        this.frameY = this.frame % this.framesPerRow;
-        this.frameX = Math.floor(this.frame / this.framesPerRow);
+        this.frameX = this.frame % this.framesPerRow;
+        this.frameY = Math.floor(this.frame / this.framesPerRow);
+
+        // Halp
+        if(isNaN(this.frameX) || !isFinite(this.frameX)) this.frameX = 0;
+        if(isNaN(this.frameY) || !isFinite(this.frameY)) this.frameY = 0;
 
         this.animationTimer = 0;
         this.draw()
@@ -130,7 +137,7 @@ export default class Emitter {
     this.sprite.style.setProperty('--left',`${parseInt(this.position.x)}px`);
     this.sprite.style.setProperty('--top',`${parseInt(this.position.y)}px`);
     this.sprite.style.setProperty('--rot',`${parseInt(rot)}deg`);
-    this.sprite.style.opacity = this.opacity;
+    this.sprite.style.opacity = this.opacity / 100;
   }
 
 }

--- a/js/NPC.js
+++ b/js/NPC.js
@@ -3,7 +3,7 @@ import Emitter from "./Emitter.js";
 export default class NPC {
   constructor(game, spriteElem, svgElem, marshalId, radius = 64) {
     this.game = game;
-    this.sprite = new Emitter(this.game, spriteElem, radius, radius, 7, false );
+    this.sprite = new Emitter(this.game, spriteElem, radius, radius, 6, false );
     this.base = svgElem;
     this.position = {x: 0, y: 0};
     this.target = {x: this.base.cx.baseVal.value, y: this.base.cy.baseVal.value};
@@ -23,9 +23,13 @@ export default class NPC {
   }
   
   draw() {
-    this.sprite.sprite.style.setProperty('--left', Math.floor(this.position.x) + 'px');
-    this.sprite.sprite.style.setProperty('--top', Math.floor(this.position.y) + 'px');
-    this.sprite.sprite.style.setProperty('--rot', Math.floor(this.facingAngle) + 'deg');
+
+    let distanceToPlayer = this.game.getDistance(this, this.game.player) 
+    if (distanceToPlayer < window.innerWidth) {
+      this.sprite.sprite.style.setProperty('--left', Math.floor(this.position.x) + 'px');
+      this.sprite.sprite.style.setProperty('--top', Math.floor(this.position.y) + 'px');
+      this.sprite.sprite.style.setProperty('--rot', Math.floor(this.facingAngle + 90) + 'deg');
+    }
     this.sprite.sprite.classList.add(this.status);
   }
   

--- a/js/Player.js
+++ b/js/Player.js
@@ -428,6 +428,13 @@ export default class Player {
 
     this.paths[this.currentPath].points.forEach( (item, index, points) => {
 
+      let distanceToPlayer = this.game.getDistance(item, this);
+      if(distanceToPlayer < window.innerWidth) {
+        item.element.dataset.display = 'onscreen';
+      } else {
+        item.element.dataset.display = '';
+      }
+
       if(item.element?.classList.contains('hit')) {
         wphits++;
       }


### PR DESCRIPTION
Closes [# 41](https://github.com/ikbensiep/game1/issues/41)  (issue in wrong repo..) 

Essentially comes down to only drawing / updating positions when dynamic items are actually in view. 

Most prominent example is the waypoint markers. 

The frame drop was caused by displaying racetrack waypoint # 1 which will end up being a far end away from the player and thus creating a large drawing canvas for the browser (even though I hid other waypoints, the next non-hit waypoint would always be drawn, and at this distance (1000s of pixels away) that becomes a large paint call. 

Now, I'm calculating if waypoints and marshals are actually (almost likely soon) within the screen, and if not, simply either not draw or update their position. 

This might even be improved by doing the same for tree, tire track and smoke sprites, but for now the gains are already significant. 

Cheers everybody, good work, drinks on me :beers: 
